### PR TITLE
Confusion about the points system

### DIFF
--- a/lib/gioco/core.rb
+++ b/lib/gioco/core.rb
@@ -18,7 +18,7 @@ class Gioco
 
       Badge.transaction do
         if TYPES && type
-          resource.points  << Point.create({ :type_id => type.id, :value => new_pontuation })
+          resource.points << Point.create({ :type_id => type.id, :value => points })
         elsif options[:points]
           resource.update_attribute( :points, new_pontuation )
         end

--- a/lib/gioco/resources.rb
+++ b/lib/gioco/resources.rb
@@ -9,7 +9,7 @@ class Gioco
         old_pontuation  = resource.points.to_i
       end
       new_pontuation    = old_pontuation + points
-      sync_resource_by_points(resource, new_pontuation, type)
+      sync_resource_by_points(resource, points, type)
     end
   end
 end

--- a/spec/specs/resources_spec.rb
+++ b/spec/specs/resources_spec.rb
@@ -21,6 +21,24 @@ describe Gioco::Resources do
         user.points.where(:type_id => type.id).sum(:value) == noob_badge.points
       end
 
+      it "Add points related to a user's type, using single increases" do
+        final_score = 4
+        final_score.times do
+          Gioco::Resources.change_points( user.id, 1, type.id)
+        end
+        user.points.where(:type_id => type.id).sum(:value).should == final_score
+      end
+
+      it "Remove points related to a user's type, using single decreases" do
+        initial_score = 10
+        final_score = 4
+        Gioco::Resources.change_points( user.id, initial_score, type.id)
+        (initial_score - final_score).times do
+          Gioco::Resources.change_points( user.id, -1, type.id)
+        end
+        user.points.where(:type_id => type.id).sum(:value).should == final_score
+      end
+
     end
 
     context "Decressing points to an user loose meidum badge" do


### PR DESCRIPTION
This PR should resolve the issue #29. When adding a new Point object to the resource, the value will be the difference being added, instead of the sum of the Points already saved plus the difference. The Point objects will work as a change history for the current score of the resource.
