### PR TITLE
Change ask setup generator

### DIFF
--- a/lib/generators/gioco/setup_generator.rb
+++ b/lib/generators/gioco/setup_generator.rb
@@ -16,7 +16,6 @@ class Gioco
     class_option :points, :kind => :boolean, :default => false, :desc => "Setup gioco with points-system based"
     class_option :kinds, :kind => :boolean, :default => false, :desc => "Setup gioco with multiples kinds(categories) of badges."
 
-
     def execute
       @model_name = ask("What is your resource model?", :default => 'user')
       generate_models


### PR DESCRIPTION
Ao tentar instalar a gem estav sempre me confundindo pois a mensagem 'eg. user' dava a entender que `user` era um valor padrão. Adicionei o parametro `:default`, não fica tão belo como a anterior mas evita o erro que me era apresentado da tentativa se manipular um @model_name vazio.
