### PR TITLE
#71 - default badges and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The both defaults badge (noob) already was added to all users that we already ha
 Inside your application if you want to give 100 points to some user, inside your function you have to use the following method:
 
 ```ruby
-kind =  Kind.where(:name => "teacher")
+kind =  Kind.find_by(:name => "teacher")
 user = User.find(1)
 
 user.change_points({ points: 100, kind: kind.id })

--- a/lib/generators/gioco/rakes_generator.rb
+++ b/lib/generators/gioco/rakes_generator.rb
@@ -29,11 +29,11 @@ namespace :gioco do
                     end\n"
 
       if arg_default
-        badge_string = badge_string + 'resources = #{@model_name.capitalize}.find(:all)\n'
+        badge_string = badge_string + 'resources = #{@model_name.capitalize}.all\n'
         badge_string = badge_string + "resources.each do |r|
         #{
         if options[:points] && options[:kinds]
-            "r.points  << Point.create({ :kind_id => kinds.id, :value => \'\#\{args.points\}\'})"
+            "r.points  << Point.create({ :kind_id => kind.id, :value => \'\#\{args.points\}\'})"
         elsif options[:points]
           "r.points = \'\#\{args.points\}\'"
         end


### PR DESCRIPTION
Pr against 1.1.1 instead of master.

Fixes adding badges with `default` set to true and update to documentation on use case.

Great product @joaomdmoura ! 